### PR TITLE
add: first draft eval bar

### DIFF
--- a/components/Evalbar.tsx
+++ b/components/Evalbar.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+interface Props {
+    evaluation: number; // 0 -> draw && 1 -> mate found for white
+}
+
+export const Evalbar: React.FC<Props> = ({ evaluation }) => {
+
+    // Function that tuns evaluation into height of the BLACK BAR 
+    function evalBarHeight(winRateWhite: number): string {
+        let calulation = winRateWhite * 50 + 50;
+        if (calulation > 100) calulation = 100;
+        if (calulation < 0) calulation = 0;
+        return (100 - calulation) + "%";
+    }
+
+
+
+    return (
+        <div>
+            <div className="w-[20px] h-[560px] bg-white border-[2px] border-black relative ">
+                <div className='w-full bg-black absolute z-10' style={{ height: evalBarHeight(evaluation) }}></div>
+                <div className='w-[18px] h-[5px] bg-gray-500 absolute z-20 top-1/2'></div>
+            </div>
+            <h6> {evaluation}</h6>
+        </div>
+
+    )
+}

--- a/pages/no-engine.tsx
+++ b/pages/no-engine.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { ChessBoard } from '../components/ChessBoard';
+import { Evalbar } from '../components/Evalbar';
 
 const noengine = () => {
 
@@ -18,9 +19,11 @@ const noengine = () => {
 
   return (
     <div>
-      <div className='flex justify-center mt-20'>
-        <ChessBoard size={70} type="default" dark={DARK_COLOR} light={LIGHT_COLOR} board={board} />
+      <div className='flex justify-center mt-20 gap-3'>
+        <Evalbar evaluation={0.2}/>
+        
       </div>
+      
 
     </div>
   )


### PR DESCRIPTION
Basic eval bar.
Designed like chess.com eval bar. But there can be changes like: 

- [x] Remove the 50% marker in the middle 
- [ ] Make animation for `onChange()`, (this could be done by passing a function as prop)

Please review :+1:  @sondrp 
(I think this is good for now)